### PR TITLE
Change default resolution to 1m

### DIFF
--- a/src/heroic_query.ts
+++ b/src/heroic_query.ts
@@ -38,7 +38,7 @@ export default class HeroicQuery {
     target.resultFormat = target.resultFormat || "time_series";
     target.orderByTime = target.orderByTime || "ASC";
     target.tags = target.tags || [];
-    target.groupBy = target.groupBy || [{ type: "time", params: ["1h"] }];
+    target.groupBy = target.groupBy || [{ type: "time", params: ["1m"] }];
     target.select = target.select || [[]];
 
     this.updateProjection();

--- a/src/query_part.ts
+++ b/src/query_part.ts
@@ -186,7 +186,7 @@ register({
       "6h", "12h", "1d", "7d", "30d"],
     },
   ],
-  defaultParams: ["1h"],
+  defaultParams: ["1m"],
   renderer: functionRenderer,
 });
 


### PR DESCRIPTION
Most metrics are emmited every 30 seconds, having the default resolution be 1h hides spikes.

Perhaps this can later be improved to calculate the resolution automatically based on the time window.